### PR TITLE
conventional-changelog is the task name

### DIFF
--- a/ch04/04_conventional-changelog/README.md
+++ b/ch04/04_conventional-changelog/README.md
@@ -3,13 +3,13 @@
 To update the changelog we would just need to run, after commiting things to `git`, following conventions as explained in the book.
 
 ```shell
-grunt changelog
+grunt conventional-changelog
 ```
 
-To merge this task with `grunt-bump`, we need to `bump-only` and then `changelog`, to finally `bump-commit`. This way we only create a single commit for both the `package.json` and `CHANGELOG.md` files. An alias can conveniently avoid mistakes:
+To merge this task with `grunt-bump`, we need to `bump-only` and then `conventional-changelog`, to finally `bump-commit`. This way we only create a single commit for both the `package.json` and `CHANGELOG.md` files. An alias can conveniently avoid mistakes:
 
 ```js
-grunt.registerTask('notes', ['bump-only', 'changelog', 'bump-commit']);
+grunt.registerTask('notes', ['bump-only', 'conventional-changelog', 'bump-commit']);
 ```
 
 There isn't much more to explain about this task, but you could play with it in a new `git` repo if you wanted to. In order to do that, copy this directory somewhere else and run `git init`, then commit a few changes, and run `grunt notes`. You could follow these commands, granted your shell is currently sitting on this directory:


### PR DESCRIPTION
The name changelog is anti pattern as task name should be always the same as module name.