### PR TITLE
updated browserify to fix esprima-six dependency issue

### DIFF
--- a/ch05/11_browserify-cjs/package.json
+++ b/ch05/11_browserify-cjs/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/buildfirst/buildfirst.git"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/01_backbone-views/package.json
+++ b/ch07/01_backbone-views/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "brfs": "^1.0.1",
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "^0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/02_backbone-view-templates/package.json
+++ b/ch07/02_backbone-view-templates/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "brfs": "^1.0.1",
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "^0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/03_backbone-models/package.json
+++ b/ch07/03_backbone-models/package.json
@@ -18,7 +18,7 @@
     "mustache": "^0.8.1"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/04_backbone-collections/package.json
+++ b/ch07/04_backbone-collections/package.json
@@ -18,7 +18,7 @@
     "mustache": "^0.8.1"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/05_backbone-routing/package.json
+++ b/ch07/05_backbone-routing/package.json
@@ -18,7 +18,7 @@
     "mustache": "^0.8.1"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/06_shopping-list/package.json
+++ b/ch07/06_shopping-list/package.json
@@ -18,7 +18,7 @@
     "jquery": "^2.1.0"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/07_the-one-with-delete-buttons/package.json
+++ b/ch07/07_the-one-with-delete-buttons/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "brfs": "^1.0.1",
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/08_creating-items/package.json
+++ b/ch07/08_creating-items/package.json
@@ -18,7 +18,7 @@
     "mustache": "^0.8.1"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/09_item-editing/package.json
+++ b/ch07/09_item-editing/package.json
@@ -18,7 +18,7 @@
     "mustache": "^0.8.1"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/10_the-road-show/package.json
+++ b/ch07/10_the-road-show/package.json
@@ -18,7 +18,7 @@
     "mustache": "^0.8.1"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/11_entourage/package.json
+++ b/ch07/11_entourage/package.json
@@ -18,7 +18,7 @@
     "rendr": "0.5.0"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "^0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch07/12_full-metal-jacket/package.json
+++ b/ch07/12_full-metal-jacket/package.json
@@ -18,7 +18,7 @@
     "rendr": "0.5.0"
   },
   "devDependencies": {
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt": "^0.4.4",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "^0.5.0",

--- a/ch08/02_tape-in-the-browser/package.json
+++ b/ch08/02_tape-in-the-browser/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "tape": "~2.10.2",
     "grunt": "~0.4.4",
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "grunt-browserify": "~1.3.2",
     "grunt-contrib-clean": "~0.5.0"
   }

--- a/ch08/07b_testability-boulevard/package.json
+++ b/ch08/07b_testability-boulevard/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "brfs": "^1.0.1",
-    "browserify": "~3.32.1",
+    "browserify": "~3.46.1",
     "glob": "^4.1.3",
     "grunt": "~0.4.4",
     "grunt-browserify": "~1.3.2",


### PR DESCRIPTION
npm install is failing:

```
npm ERR! 404 Registry returned 404 for GET on
https://registry.npmjs.org/esprima-six
npm ERR! 404
npm ERR! 404 'esprima-six' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name
yourself!)
npm ERR! 404 It was specified as a dependency of 'derequire'
```
Updating to the next minor version of browserify fixes the issue